### PR TITLE
Add alerting option

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -4,6 +4,11 @@ global:
   external_labels:                                                              
       monitor: 'exporter-metrics'                                                
                                                                                 
+alerting:
+  alertmanagers:
+    - static_configs:
+      - targets: ["alertmanager:9093"]
+
 scrape_configs:
 
 - job_name: 'HostsMetrics'


### PR DESCRIPTION
For last version of Prometheus (2.1.0) the command line option -alertmanager.url=http://alertmanager:9093 din't work anymore.

We need an alerting option into prometheus.yml